### PR TITLE
[Fix] implement requiresMainQueueSetup

### DIFF
--- a/ios/CashfreeEventEmitter.swift
+++ b/ios/CashfreeEventEmitter.swift
@@ -9,16 +9,20 @@ import Foundation
 
 @objc(CashfreeEventEmitter)
 open class CashfreeEventEmitter: RCTEventEmitter {
-    
+
     override init() {
         super.init()
         CashfreeEmitter.sharedInstance.registerEventEmitter(eventEmitter: self)
     }
-    
+
     /// Base overide for RCTEventEmitter.
     ///
     /// - Returns: all supported events
     @objc open override func supportedEvents() -> [String] {
         return CashfreeEmitter.sharedInstance.allEvents
+    }
+
+    @objc public override static func requiresMainQueueSetup() -> Bool {
+        return false
     }
 }

--- a/ios/CashfreePgApi.swift
+++ b/ios/CashfreePgApi.swift
@@ -5,6 +5,14 @@ import CashfreePG
 @objc(CashfreePgApi)
 class CashfreePgApi: NSObject {
 
+    override init() {
+        super.init()
+    }
+
+    @objc static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
     @objc func doPayment(_ paymentObject: NSString) -> Void {
         do {
             let dropObject = try! parseDropPayment(paymentObject: "\(paymentObject)")


### PR DESCRIPTION
Module CashfreePgApi.swift and CashfreeEventEmitter.swift requires main queue setup since it overrides init but doesn't implement requiresMainQueueSetup